### PR TITLE
The osfamily fact is always Debian, use operatingsystem fact instead

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,14 +11,12 @@ class sumo::params {
       $sumo_service_name  = 'collector'
       $syncsources    = '/etc/sumo.sources.d'
     }
-    'Debian': {
-      $sumo_package_name   = 'SumoCollector'
-      $sumo_service_config  = '/etc/sumo.conf'
-      $sumo_service_name  = 'collector'
-      $syncsources    = '/etc/sumo.sources.d'
-    }
-    'Ubuntu': {
-      $sumo_package_name   = 'sumocollector'
+    /^(Debian|Ubuntu)$/: {
+      if $::operatingsystem == 'Ubuntu' {
+        $sumo_package_name   = 'sumocollector'
+      } else {
+        $sumo_package_name   = 'SumoCollector'
+      }
       $sumo_service_config  = '/etc/sumo.conf'
       $sumo_service_name  = 'collector'
       $syncsources    = '/etc/sumo.sources.d'


### PR DESCRIPTION
In our apt repo, the `sumocollector` is in lowercase, so we need to make this distinction in Ubuntu. But the `osfamily` fact is always `Debian` (even in ubuntu), so the correct fact to check if it's ubuntu is `operatingsystem`.